### PR TITLE
Update setup.py (fixe mcu list issue)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def supported_mcus():
 	proc = subprocess.Popen('avr-gcc -Wa,-mlist-devices --target-help', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 	out, err = proc.communicate()
 	exitcode = proc.returncode
-	lines = string.split(out, '\n')
+	lines = string.split(err, '\n')
 
 	mcus = []
 	consider = False


### PR DESCRIPTION
must change : lines = string.split(out, '\n') --> lines = string.split(err, '\n') in order to have all mcus supported by avr-gcc within the xavr wizard window